### PR TITLE
[fix] ブログページの次へを押すと404になるバグ修正

### DIFF
--- a/src/templates/blog.js
+++ b/src/templates/blog.js
@@ -44,7 +44,7 @@ export default function Blog(props) {
           <h2>
             Written By: {data.frontmatter.author}
           </h2>
-          <Link to={`blog/${nextSlug}`} className={blogTemplateStyles.footer__next}>
+          <Link to={`/blog/${nextSlug}`} className={blogTemplateStyles.footer__next}>
             <svg xmlns="http://www.w3.org/2000/svg"  version="1.1" x="0px" y="0px" viewBox="0 0 26 26" enableBackground="new 0 0 26 26" >
               <path d="M23.021,12.294l-8.714-8.715l-1.414,1.414l7.007,7.008H2.687v2h17.213l-7.007,7.006l1.414,1.414l8.714-8.713  C23.411,13.317,23.411,12.685,23.021,12.294z"/>
             </svg>


### PR DESCRIPTION
## 修正内容
ブログページの一番右下にある右矢印のボタンを押すと
(ブログAとBが順番に並んでる時)

/blog/A => /blog/B
にページ遷移するはずが

/blog/A => /blog/A/blog/B
になって404のページが出てたので正しい動きになるように修正。